### PR TITLE
Specifying Traefik image version

### DIFF
--- a/traefik-helper.default.yml
+++ b/traefik-helper.default.yml
@@ -10,7 +10,7 @@ version: '2'
 
 services:
   traefik:
-    image: traefik
+    image: traefik:1.7
     restart: unless-stopped
     command: -c /dev/null --web --docker --logLevel=DEBUG
     networks:


### PR DESCRIPTION
Added Traefik image version (1.7) that needs to be downloaded. Without version, it will always download the latest version (v2.0). 

But, with the latest version i.e.2.0, shell script is throwing error because of internal command being used in the shell script. Instead, mentioning the version 1.7 (working till 1.7) will help resolve the error.